### PR TITLE
solana web3 intergration

### DIFF
--- a/src/client/wallet_test.ts
+++ b/src/client/wallet_test.ts
@@ -450,6 +450,7 @@ export async function sayHelloWithContractWallet(): Promise<void> {
   const transaction = await Wallet.createInvokeTransaction(
     programId,
     walletPubkey,
+    payerAccount.publicKey,
     internalTransaction,
     signers,
   );

--- a/src/program/src/instruction.rs
+++ b/src/program/src/instruction.rs
@@ -23,7 +23,7 @@ pub enum WalletInstruction {
   /// Remove a Pubkey from owner list
   RemoveOwner {
     /// The public key to remove from the owner list
-    pubkey: Pubkey
+    pubkey: Pubkey,
   },
   /// Recovery can reset all your account owners
   Recovery {
@@ -33,7 +33,7 @@ pub enum WalletInstruction {
   /// Invoke an instruction to another program
   Invoke {
     /// The instruction for the wallet to invoke
-    instruction: Instruction
+    instruction: Instruction,
   },
   /// Revoke will freeze wallet
   Revoke,
@@ -56,13 +56,13 @@ impl WalletInstruction {
           let weight = read_u16(&mut current, rest).unwrap();
           owners.insert(pubkey, weight);
         }
-        Self::AddOwner {owners: owners}
+        Self::AddOwner { owners: owners }
       }
       // RemoveOwner
       1 => {
         let (pubkey, _) = Self::unpack_pubkey(rest)?;
         Self::RemoveOwner { pubkey }
-      },
+      }
       // Recovery
       2 => {
         let mut current = 0;
@@ -72,8 +72,8 @@ impl WalletInstruction {
           let weight = read_u16(&mut current, rest).unwrap();
           owners.insert(pubkey, weight);
         }
-        Self::Recovery {owners: owners}
-      },
+        Self::Recovery { owners: owners }
+      }
       // Invoke
       3 => {
         let mut current = 0;
@@ -113,37 +113,29 @@ impl WalletInstruction {
     let mut buf = Vec::with_capacity(size_of::<Self>());
 
     match self {
-      &Self::AddOwner {
-        owners: _,
-      } => {
+      &Self::AddOwner { owners: _ } => {
         buf.push(0);
         // TODO
-      },
-      &Self::RemoveOwner {
-        ref pubkey,
-      } => {
+      }
+      &Self::RemoveOwner { ref pubkey } => {
         buf.push(1);
         buf.extend_from_slice(pubkey.as_ref());
       }
-      &Self::Recovery {
-        owners: _,
-      } => {
+      &Self::Recovery { owners: _ } => {
         buf.push(2)
         // TODO
       }
-      &Self::Invoke {
-        ref instruction,
-      } => {
+      &Self::Invoke { ref instruction } => {
         buf.push(3);
         buf.extend_from_slice(instruction.program_id.as_ref());
         // TODO: Complete invoke instruction packing
       }
       &Self::Revoke => {
         buf.push(4);
-      },
+      }
       &Self::Hello => {
         buf.push(5);
-      },
+      }
     }
 
     buf

--- a/src/program/src/instruction.rs
+++ b/src/program/src/instruction.rs
@@ -30,15 +30,15 @@ pub enum WalletInstruction {
     /// The public key to remove from the owner list
     pubkey: Pubkey
   },
-  /// Invoke an instruction to another program
-  Invoke {
-    /// The instruction for the wallet to invoke
-    instruction: Instruction
-  },
   /// Recovery can reset all your account owners
   Recovery {
     /// public key => key weight
     owners: BTreeMap<Pubkey, u16>,
+  },
+  /// Invoke an instruction to another program
+  Invoke {
+    /// The instruction for the wallet to invoke
+    instruction: Instruction
   },
   /// Revoke will freeze wallet
   Revoke,

--- a/src/program/src/processor.rs
+++ b/src/program/src/processor.rs
@@ -148,7 +148,6 @@ impl Processor {
     for account in &mut instruction.accounts {
       if &account.pubkey == payer_account.key {
         account.is_signer = false;
-        account.is_writable = false;
       }
     }
 

--- a/src/program/src/processor.rs
+++ b/src/program/src/processor.rs
@@ -259,7 +259,7 @@ impl Processor {
       Self::check_signatures(accounts, &wallet_account)?;
     }
 
-    let instruction = WalletInstruction::unpack(input)?;
+    let instruction = WalletInstruction::unpack(input, &accounts)?;
 
     match instruction {
       WalletInstruction::Hello if is_wallet_initialized => {


### PR DESCRIPTION
1. pack account index into data instead of full public key
2. use only 1 byte to store IsSigner and IsWritable attributes
3. don't drop feePayer writable feature
4. some lint 